### PR TITLE
implied marketplace in the ticker causes ValueError creating the Data…

### DIFF
--- a/examples/example_calls.py
+++ b/examples/example_calls.py
@@ -5,10 +5,10 @@ con = pdblp.BCon(debug=True)
 con.start()
 
 # simple bdh call
-con.bdh('SPY Equity', 'PX_LAST', '20150629', '20150630')
+con.bdh('SPY US Equity', 'PX_LAST', '20150629', '20150630')
 
 # two fields returns MultiIndex
-con.bdh('SPY Equity', ['PX_LAST', 'VOLUME'], '20150629', '20150630')
+con.bdh('SPY US Equity', ['PX_LAST', 'VOLUME'], '20150629', '20150630')
 
 # bdh with override
 con.bdh('MPMIEZMA Index', 'PX_LAST', '20150101', '20150830')


### PR DESCRIPTION
without the US I got this, might be dependant on internal bloomberg settings, i guess you got US in defaults which might not be the case for everyone,
that said, the ref method should return some kind of 'error' in case there is that answer

C:\Python27\python.exe D:/PycharmProjects/pdblp/examples/example_calls.py
DEBUG:root:Sending Request:
 HistoricalDataRequest = {
    securities[] = {
        "SPY Equity"
    }
    fields[] = {
        "PX_LAST"
    }
    periodicityAdjustment = ACTUAL
    periodicitySelection = DAILY
    startDate = "20150629"
    endDate = "20150630"
    overrides[] = {
    }
}

DEBUG:root:Message Received:
 HistoricalDataResponse = {
    securityData = {
        security = "SPY Equity"
        eidData[] = {
        }
        sequenceNumber = 0
        fieldExceptions[] = {
        }
        fieldData[] = {
        }
    }
}

Traceback (most recent call last):
  File "D:/PycharmProjects/pdblp/examples/example_calls.py", line 8, in <module>
    con.bdh('SPY Equity', 'PX_LAST', '20150629', '20150630')
  File "C:\Python27\lib\site-packages\pdblp-0.0.1-py2.7.egg\pdblp\pdblp.py", line 156, in bdh
    data.columns.names = ['ticker', 'field']
  File "C:\Python27\lib\site-packages\pandas\core\index.py", line 596, in _set_names
    % len(values))
ValueError: Length of new names must be 1, got 2

Process finished with exit code 1
