### PR TITLE
Update pdblp.py

### DIFF
--- a/pdblp/pdblp.py
+++ b/pdblp/pdblp.py
@@ -267,6 +267,85 @@ class BCon(object):
                 break
 
         return data
+    
+    # new bdsp function is designed to retrieve the tickers in a portfolio list 
+    # the function is identical to ref except that the request type is a PortfolioData Request
+    
+    def bdsp(self, tickers, flds=[], ovrds=[]): # changed so that fields is empty by default
+            
+        '''
+        Make a reference data request, get tickers and fields, return long
+        pandas Dataframe with columns [ticker, field, value]
+        Parameters
+        ----------
+        tickers: {list, string}
+            String or list of strings corresponding to tickers
+        flds: {list, string}
+            String or list of strings corresponding to FLDS
+        ovrds: list of tuples
+            List of tuples where each tuple corresponds to the override
+            field and value
+        '''
+
+        data = self._bdspref(tickers, flds, ovrds)
+
+        data = DataFrame(data)
+        
+        data.columns = ["ticker", "field", "values"]
+        return data
+
+    def _bdspref(self, tickers, flds, ovrds):
+
+        if type(tickers) is not list:
+            tickers = [tickers]
+        if type(flds) is not list:
+            flds = [flds]
+            
+        # the function is identical to ref except that the request type is a PortfolioData Request
+        request = self._create_req("PortfolioDataRequest", tickers, flds,
+                                   ovrds, [])
+
+        logging.debug("Sending Request:\n %s" % request)
+        # Send the request
+        self.session.sendRequest(request)
+        data = []
+        # Process received events
+        while(True):
+            # We provide timeout to give the chance for Ctrl+C handling:
+            ev = self.session.nextEvent(500)
+            for msg in ev:
+                logging.debug("Message Received:\n %s" % msg)
+                fldData = msg.getElement('securityData')
+                for i in range(fldData.numValues()):
+                    ticker = (fldData.getValue(i).getElement("security").getValue())  # NOQA
+                    reqFldsData = (fldData.getValue(i).getElement('fieldData'))
+                    
+                    for j in range(reqFldsData.numElements()):
+                        fld = flds[j]
+                        # this is for dealing with requests which return arrays
+                        # of values for a single field
+                        if reqFldsData.getElement(fld).isArray():
+                            lrng = reqFldsData.getElement(fld).numValues()
+                            for k in range(lrng):
+                                elms = (reqFldsData.getElement(fld).getValue(k).elements())  # NOQA
+                                # if the elements of the array have multiple
+                                # subelements this will just append them all
+                                # into a list
+                                for elm in elms:
+                                    data.append([ticker, fld, elm.getValue()])
+                        else:
+                            val = reqFldsData.getElement(fld).getValue()
+                            data.append([ticker, fld, val])
+
+            if ev.eventType() == blpapi.Event.RESPONSE:
+                # Response completely received, so we could exit
+                break
+
+        return data
+    
+    
+    
+    
 
     def ref_hist(self, tickers, flds, start_date,
                  end_date=datetime.date.today().strftime('%Y%m%d'),


### PR DESCRIPTION
 @matthewgilbert 
added a function to create dataframe from a portfolio

The developers guide says that 

The BDS() function requests bulk reference data for a single security and bulk field. In the API, there is no difference in the request type and options for reference data and bulk reference data (the field dictates if it is bulk). The difference between the two lies in parsing the response—bulk data responses are returned in a different format.

This is not quite the case, a portfolio data request requires a different request type.

The added function bdsp(self, tickers, flds=[], ovrds=[])  will return a BDS style dataframe for a portfolio.  Usage is the same as ref.

 
df =  con.bdsp(portfolio , field )

Where portfolio  = 'portfolioID Client' and field is from 
PORTFOLIO_ASSET_CLASS
The type of assets held within a user's custom portfolio.
PORTFOLIO_BASE_CURRENCY
The currency in which a user's custom portfolio is denominated.
PORTFOLIO_BENCHMARK
The name of the security, index, or custom portfolio used as the benchmark associated with a user's portfolio.
PORTFOLIO_DATA
The list of the identifiers, positions, market values, cost, cost date, and cost foreign exchange rate of each security in a user's custom portfolio.
PORTFOLIO_MEMBERS
The list of identifiers for the members of a user's custom portfolio.
PORTFOLIO_MPOSITION
The list of identifiers and the position for each security in a user's custom portfolio.
PORTFOLIO_MWEIGHT
The list of identifiers and the percentage weight for each security in a user's custom portfolio.
PORTFOLIO_NAME
The name assigned to the user's custom portfolio.
PORTFOLIO_POSITION_TYPE
The manner in which securities are represented in a user's custom portfolio. Position types include: shares / par amount, fixed weight, and drifting weight.

eg df1 =  con.bdsp("U123456-78 Client", "PORTFOLIO_MEMBERS" )