### PR TITLE
SECF() implementation

### DIFF
--- a/pdblp/pdblp.py
+++ b/pdblp/pdblp.py
@@ -182,6 +182,20 @@ class BCon(object):
             raise ConnectionError("Could not open a //blp/exrsvc service")
         self.exrService = self._session.getService("//blp/exrsvc")
 
+        opened = self._session.openService("//blp/instruments")
+        ev = self._session.nextEvent()
+        ev_name = _EVENT_DICT[ev.eventType()]
+        logger.info("Event Type: %s" % ev_name)
+        for msg in ev:
+            logger.info("Message Received:\n%s" % msg)
+        if ev.eventType() != blpapi.Event.SERVICE_STATUS:
+            raise RuntimeError("Expected a SERVICE_STATUS event but "
+                               "received a %s" % ev_name)
+        if not opened:
+            logger.warning("Failed to open //blp/exrsvc")
+            raise ConnectionError("Could not open a //blp/instruments service")
+        self.instrService = self._session.getService("//blp/instruments")
+
         return self
 
     def _create_req(self, rtype, tickers, flds, ovrds, setvals):
@@ -731,6 +745,44 @@ class BCon(object):
                     data.append(f.getElementAsString("StringValue"))
         return pd.DataFrame(data)
 
+    def secf(self, query, max_results=10, yk_filter="NONE"):
+        """
+        This function uses the Bloomberg API to retrieve Bloomberg
+        SECF Data queries. Returns list of tickers.
+
+        Parameters
+        ----------
+        query: string
+            A character string representing the desired query. Example "IBM"
+        max_results: int
+            Maximum number of results to return. Default 10. 
+        yk_filter: string
+            A character string respresenting a Bloomberg yellow-key to limit
+            search results to. Valid values are: CMDT, EQTY, MUNI, 
+            PRFD, CLNT, MMKT, GOVT, CORP, INDX, CURR, MTGE. Default NONE.
+
+        Returns
+        -------
+        data: list
+            List of bloomberg tickers from the SECF function
+        """
+        logger = _get_logger(self.debug)
+        request = self.instrService.createRequest("instrumentListRequest")
+        request.set("query", query)
+        request.set("maxResults", max_results)
+        request.set("yellowKeyFilter", "YK_FILTER_%s" % yk_filter)
+        logger.info("Sending Request:\n%s" % request)
+        self._session.sendRequest(request, identity=self._identity)
+        data = []
+        for msg in self._receive_events():
+            for r in msg.getElement("results").values():
+                ticker = r.getElementAsString("security")
+                ticker = ticker.replace('<', ' ').replace('>', '').upper()
+                descr = r.getElementAsString("description")
+                if not descr.endswith('(Multiple Matches)'):
+                    data.append(ticker)
+        return data
+        
     def stop(self):
         """
         Close the blp session

--- a/pdblp/pdblp.py
+++ b/pdblp/pdblp.py
@@ -755,15 +755,15 @@ class BCon(object):
         query: string
             A character string representing the desired query. Example "IBM"
         max_results: int
-            Maximum number of results to return. Default 10. 
+            Maximum number of results to return. Default 10.
         yk_filter: string
             A character string respresenting a Bloomberg yellow-key to limit
-            search results to. Valid values are: CMDT, EQTY, MUNI, 
+            search results to. Valid values are: CMDT, EQTY, MUNI,
             PRFD, CLNT, MMKT, GOVT, CORP, INDX, CURR, MTGE. Default NONE.
 
         Returns
         -------
-        data: list
+        data: pandas.DataFrame
             List of bloomberg tickers from the SECF function
         """
         logger = _get_logger(self.debug)
@@ -780,9 +780,9 @@ class BCon(object):
                 ticker = ticker.replace('<', ' ').replace('>', '').upper()
                 descr = r.getElementAsString("description")
                 if not descr.endswith('(Multiple Matches)'):
-                    data.append(ticker)
-        return data
-        
+                    data.append((ticker, descr))
+        return pd.DataFrame(data, columns=['ticker', 'description'])
+
     def stop(self):
         """
         Close the blp session

--- a/pdblp/tests/test_pdblp.py
+++ b/pdblp/tests/test_pdblp.py
@@ -477,6 +477,18 @@ def test_bsrch(con):
     assert_frame_equal(df, df_expect)
 
 
+@ifbbg
+def test_secf(con):
+    df = con.secf(query="IBM",
+                  yk_filter="EQTY",
+                  max_results=1)
+    df_expect = pd.DataFrame(
+        {"ticker": ["IBM US EQUITY"],
+         "description": ["International Business Machines Corp (U.S.)"]}
+    )
+    assert_frame_equal(df, df_expect)
+
+
 def test_connection_error(port):
     con = pdblp.BCon(port=port+1)
     with pytest.raises(ConnectionError):


### PR DESCRIPTION
Closes #49 - all tests added / passed

```
>>> import pdblp
>>> con = pdblp.BCon(port=8194, timeout=5000)
>>> con.start()
>>> con.secf("IBM")
                        ticker                                        description
0                IBM US EQUITY        International Business Machines Corp (U.S.)
1                IBM UN EQUITY    International Business Machines Corp (New York)
2                IBM LN EQUITY      International Business Machines Corp (London)
3  IBM US 01/17/20 C145 EQUITY              January 20 Calls on IBM US Strike 145
4                IBM GR EQUITY     International Business Machines Corp (Germany)
5                IBM FP EQUITY  International Business Machines Corp (Euronext...
6  IBM US 10/19/18 C150 EQUITY              October 18 Calls on IBM US Strike 150
7                      IBM PFD               International Business Machines Corp
8                IBM CN EQUITY      International Business Machines Corp (Canada)
```

Returns a pd.DataFrame to be consistent with other functions.
