### PR TITLE
ENH: Allow arbitrary date formats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,3 +53,7 @@ file for building docs
 - Refactor pdblp to use blpapi.Messages parsed into dicts
 - Remove conda package building
 - Remove testing for python 3.5 and 3.4
+
+# pdblp 0.1.9
+
+ - Allow arbitrary dates formats

--- a/pdblp/pdblp.py
+++ b/pdblp/pdblp.py
@@ -267,15 +267,9 @@ class BCon(object):
         start_date = f"{pd.to_datetime(start_date):%Y%m%d}"
         end_date = f"{pd.to_datetime(end_date):%Y%m%d}"
 
-        ovrds = [] if not ovrds else ovrds
+        ovrds = [] if not ovrds else [(field, _todate_greedy(date))
+                                      for (field, date) in ovrds]
         elms = [] if not elms else elms
-
-        def _todate_greedy(date):
-            try:
-                return f"{pd.to_datetime(date):%Y%m%d}"
-            except (ValueError, TypeError, OverflowError):
-                return date
-        ovrds = [_todate_greedy(ovrd) for ovrd in ovrds]
 
         elms = list(elms)
 
@@ -360,7 +354,8 @@ class BCon(object):
                 FUT_GEN_MONTH = "FGHJKMNQUVXZ"
         }
         """
-        ovrds = [] if not ovrds else ovrds
+        ovrds = [] if not ovrds else [(field, _todate_greedy(date))
+                                      for (field, date) in ovrds]
 
         logger = _get_logger(self.debug)
         if type(tickers) is not list:
@@ -461,7 +456,8 @@ class BCon(object):
             }
         }
         """
-        ovrds = [] if not ovrds else ovrds
+        ovrds = [] if not ovrds else [(field, _todate_greedy(date))
+                                      for (field, date) in ovrds]
 
         logger = _get_logger(self.debug)
         if type(tickers) is not list:
@@ -553,7 +549,8 @@ class BCon(object):
 
         """
         dates = [f"{date:%Y%m%d}" for date in pd.to_datetime(dates)]
-        ovrds = [] if not ovrds else ovrds
+        ovrds = [] if not ovrds else [(field, _todate_greedy(date))
+                                      for (field, date) in ovrds]
 
         if type(tickers) is not list:
             tickers = [tickers]
@@ -761,3 +758,10 @@ def message_to_dict(msg):
         'topicName': msg.topicName(),
         'element': _element_to_dict(msg.asElement())
     }
+
+
+def _todate_greedy(date):
+    try:
+        return f"{pd.to_datetime(date):%Y%m%d}"
+    except (ValueError, TypeError, OverflowError):
+        return date

--- a/pdblp/pdblp.py
+++ b/pdblp/pdblp.py
@@ -10,12 +10,12 @@ _RESPONSE_TYPES = [blpapi.Event.RESPONSE, blpapi.Event.PARTIAL_RESPONSE]
 
 # partial lookup table for events used from blpapi.Event
 _EVENT_DICT = {
-              blpapi.Event.SESSION_STATUS: 'SESSION_STATUS',
-              blpapi.Event.RESPONSE: 'RESPONSE',
-              blpapi.Event.PARTIAL_RESPONSE: 'PARTIAL_RESPONSE',
-              blpapi.Event.SERVICE_STATUS: 'SERVICE_STATUS',
-              blpapi.Event.TIMEOUT: 'TIMEOUT',
-              blpapi.Event.REQUEST: 'REQUEST'
+    blpapi.Event.SESSION_STATUS: 'SESSION_STATUS',
+    blpapi.Event.RESPONSE: 'RESPONSE',
+    blpapi.Event.PARTIAL_RESPONSE: 'PARTIAL_RESPONSE',
+    blpapi.Event.SERVICE_STATUS: 'SERVICE_STATUS',
+    blpapi.Event.TIMEOUT: 'TIMEOUT',
+    blpapi.Event.REQUEST: 'REQUEST'
 }
 
 
@@ -251,10 +251,8 @@ class BCon(object):
             String or list of strings corresponding to tickers
         flds: {list, string}
             String or list of strings corresponding to FLDS
-        start_date: string
-            String in format YYYYmmdd
-        end_date: string
-            String in format YYYYmmdd
+        start_date: {string, datetime, date}
+        end_date: {string, datetime, date}
         elms: list of tuples
             List of tuples where each tuple corresponds to the other elements
             to be set, e.g. [("periodicityAdjustment", "ACTUAL")].
@@ -266,8 +264,18 @@ class BCon(object):
         longdata: boolean
             Whether data should be returned in long data format or pivoted
         """
+        start_date = f"{pd.to_datetime(start_date):%Y%m%d}"
+        end_date = f"{pd.to_datetime(end_date):%Y%m%d}"
+
         ovrds = [] if not ovrds else ovrds
         elms = [] if not elms else elms
+
+        def _todate_greedy(date):
+            try:
+                return f"{pd.to_datetime(date):%Y%m%d}"
+            except (ValueError, TypeError, OverflowError):
+                return date
+        ovrds = [_todate_greedy(ovrd) for ovrd in ovrds]
 
         elms = list(elms)
 
@@ -285,6 +293,8 @@ class BCon(object):
 
     def _bdh_list(self, tickers, flds, start_date, end_date, elms,
                   ovrds):
+        start_date = f"{pd.to_datetime(start_date):%Y%m%d}"
+        end_date = f"{pd.to_datetime(end_date):%Y%m%d}"
         logger = _get_logger(self.debug)
         if type(tickers) is not list:
             tickers = [tickers]
@@ -524,7 +534,7 @@ class BCon(object):
         flds: {list, string}
             String or list of strings corresponding to FLDS
         dates: list
-            list of date strings in the format YYYYmmdd
+            list of dates
         ovrds: list of tuples
             List of tuples where each tuple corresponds to the override
             field and value. This should not include the date_field which will
@@ -542,6 +552,7 @@ class BCon(object):
         >>> con.ref_hist("AUD1M CMPN Curncy", "SETTLE_DT", dates)
 
         """
+        dates = [f"{date:%Y%m%d}" for date in pd.to_datetime(dates)]
         ovrds = [] if not ovrds else ovrds
 
         if type(tickers) is not list:
@@ -572,7 +583,7 @@ class BCon(object):
         flds: {list, string}
             String or list of strings corresponding to FLDS
         dates: list
-            list of date strings in the format YYYYmmdd
+            list of dates
         ovrds: list of tuples
             List of tuples where each tuple corresponds to the override
             field and value. This should not include the date_field which will
@@ -591,6 +602,7 @@ class BCon(object):
         ...                  date_field="CURVE_DATE")
 
         """
+        dates = [f"{date:%Y%m%d}" for date in pd.to_datetime(dates)]
         ovrds = [] if not ovrds else ovrds
 
         if type(tickers) is not list:
@@ -608,6 +620,7 @@ class BCon(object):
         return data
 
     def _send_hist(self, tickers, flds, dates, date_field, ovrds):
+        dates = [f"{date:%Y%m%d}" for date in pd.to_datetime(dates)]
         logger = _get_logger(self.debug)
         setvals = []
         request = self._create_req('ReferenceDataRequest', tickers, flds,
@@ -637,10 +650,10 @@ class BCon(object):
         ----------
         ticker: string
             String corresponding to ticker
-        start_datetime: string
-            UTC datetime in format YYYY-mm-ddTHH:MM:SS
-        end_datetime: string
-            UTC datetime in format YYYY-mm-ddTHH:MM:SS
+        start_datetime: {string, datetime}
+            UTC datetime
+        end_datetime: {string, datetime}
+            UTC datetime
         event_type: string {TRADE, BID, ASK, BID_BEST, ASK_BEST, BEST_BID,
                            BEST_ASK}
             Requested data event type
@@ -651,6 +664,8 @@ class BCon(object):
             to be set. Refer to the IntradayBarRequest section in the
             'Services & schemas reference guide' for more info on these values
         """
+        start_datetime = f"{pd.to_datetime(start_datetime):%Y-%m-%dT%H:%M:%S}"
+        end_datetime = f"{pd.to_datetime(end_datetime):%Y-%m-%dT%H:%M:%S}"
         elms = [] if not elms else elms
 
         # flush event queue in case previous call errored out

--- a/pdblp/tests/test_pdblp.py
+++ b/pdblp/tests/test_pdblp.py
@@ -281,9 +281,9 @@ def test_ref_one_ticker_one_field(con):
     assert_frame_equal(df, df_expect)
 
 
-@pytest.mark.parametrize("date", [("20161010",), ("2016-10-10",),
-                         ("2016/10/10",), ("10Jun2016"),
-                         (pd.datetime(2016, 6, 10),), (pd.Timestamp(2016, 6, 10),)])
+@pytest.mark.parametrize("date", ["20161010", "2016-10-10",
+                         "2016/10/10", "10Oct2016",
+                         pd.datetime(2016, 10, 10), pd.Timestamp(2016, 10, 10,)])
 @ifbbg
 def test_ref_one_ticker_one_field_override(con, date):
     df = con.ref('AUD Curncy', 'SETTLE_DT',
@@ -345,9 +345,9 @@ def test_ref_mixed_data_error(con):
 
 
 # BULKREF TESTS
-@pytest.mark.parametrize("date", [("20150530",), ("2015-05-30",),
-                         ("2015/05/30",), ("30May2015"),
-                         (pd.datetime(2015, 5, 30),), (pd.Timestamp(2015, 5, 30),)])
+@pytest.mark.parametrize("date", ["20150530", "2015-05-30",
+                         "2015/05/30", "30May2015",
+                         pd.datetime(2015, 5, 30), pd.Timestamp(2015, 5, 30)])
 @ifbbg
 def test_bulkref_one_ticker_one_field(con, data_path, date):
     df = con.bulkref('BCOM Index', 'INDX_MWEIGHT',
@@ -358,9 +358,9 @@ def test_bulkref_one_ticker_one_field(con, data_path, date):
     pivot_and_assert(df, df_expected)
 
 
-@pytest.mark.parametrize("date", [("20150530",), ("2015-05-30",),
-                         ("2015/05/30",), ("30May2015"),
-                         (pd.datetime(2015, 5, 30),), (pd.Timestamp(2015, 5, 30),)])
+@pytest.mark.parametrize("date", ["20150530", "2015-05-30",
+                         "2015/05/30", "30May2015",
+                         pd.datetime(2015, 5, 30), pd.Timestamp(2015, 5, 30)])
 @ifbbg
 def test_bulkref_two_ticker_one_field(con, data_path, date):
     df = con.bulkref(['BCOM Index', 'OEX Index'], 'INDX_MWEIGHT',
@@ -427,7 +427,7 @@ def test_bulkref_not_applicable_with_applicable_field_smoketest(con):
 def test_hist_ref_one_ticker_one_field_numeric(con, dates):
     df = con.ref_hist("AUD1M CMPN Curncy", "DAYS_TO_MTY", dates)
     df_expect = pd.DataFrame(
-        {"date": dates,
+        {"date": ["20160104", "20160105"],
          "ticker": ["AUD1M CMPN Curncy", "AUD1M CMPN Curncy"],
          "field": ["DAYS_TO_MTY", "DAYS_TO_MTY"],
          "value": [33, 32]}
@@ -442,7 +442,7 @@ def test_hist_ref_one_ticker_one_field_numeric(con, dates):
 def test_hist_ref_one_ticker_one_field_non_numeric(con, dates):
     df = con.ref_hist("AUD1M CMPN Curncy", "SETTLE_DT", dates)
     df_expect = pd.DataFrame(
-        {"date": dates,
+        {"date": ["20160104", "20160105"],
          "ticker": ["AUD1M CMPN Curncy", "AUD1M CMPN Curncy"],
          "field": ["SETTLE_DT", "SETTLE_DT"],
          "value": 2 * [pd.datetime(2016, 2, 8).date()]}
@@ -479,8 +479,8 @@ def test_bulkhist_ref_with_alternative_reference_field(con, dates):
                          ("2015/06/29", "30Jun2015"),
                          (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
 @ifbbg
-def test_context_manager(port, host, start_date, end_date):
-    with pdblp.bopen(host=host, port=port) as bb:
+def test_context_manager(port, host, timeout, start_date, end_date):
+    with pdblp.bopen(host=host, port=port, timeout=timeout) as bb:
         df = bb.bdh('SPY US Equity', 'PX_LAST', start_date, end_date)
     midx = pd.MultiIndex(levels=[["SPY US Equity"], ["PX_LAST"]],
                          labels=[[0], [0]], names=["ticker", "field"])

--- a/pdblp/tests/test_pdblp.py
+++ b/pdblp/tests/test_pdblp.py
@@ -89,31 +89,41 @@ ifbbg = pytest.mark.skipif(pytest.config.cache.get('offline', False),
                            reason="No BBG connection, skipping tests")
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20180510", "2018-05-11"), ("2018/05/10", "11May2018"),
+     (pd.datetime(2018, 5, 10), pd.Timestamp(2018, 5, 11))]
+)
 @ifbbg
-def test_bdh_empty_data_only(con):
+def test_bdh_empty_data_only(con, start_date, end_date):
     df = con.bdh(
-            tickers=['1437355D US Equity'],
-            flds=['PX_LAST', 'VOLUME'],
-            start_date='20180510',
-            end_date='20180511',
-            longdata=False
+        tickers=['1437355D US Equity'],
+        flds=['PX_LAST', 'VOLUME'],
+        start_date=start_date,
+        end_date=end_date,
+        longdata=False
     )
     df_exp = pd.DataFrame(
-      [], index=pd.DatetimeIndex([], name='date'),
-      columns=pd.MultiIndex.from_product([[], []],
-                                         names=('ticker', 'field'))
+        [],
+        index=pd.DatetimeIndex([], name='date'),
+        columns=pd.MultiIndex.from_product([[], []], names=('ticker', 'field'))
     )
     assert_frame_equal(df, df_exp)
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20180510", "2018-05-11"), ("2018/05/10", "11May2018"),
+     (pd.datetime(2018, 5, 10), pd.Timestamp(2018, 5, 11))]
+)
 @ifbbg
-def test_bdh_empty_data_with_non_empty_data(con):
+def test_bdh_empty_data_with_non_empty_data(con, start_date, end_date):
     df = con.bdh(
-            tickers=['AAPL US Equity', '1437355D US Equity'],
-            flds=['PX_LAST', 'VOLUME'],
-            start_date='20180510',
-            end_date='20180511',
-            longdata=False
+        tickers=['AAPL US Equity', '1437355D US Equity'],
+        flds=['PX_LAST', 'VOLUME'],
+        start_date=start_date,
+        end_date=end_date,
+        longdata=False
     )
     df_exp = pd.DataFrame(
         [[190.04, 27989289.0], [188.59, 26212221.0]],
@@ -125,29 +135,39 @@ def test_bdh_empty_data_with_non_empty_data(con):
     assert_frame_equal(df, df_exp)
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20180215", "2018-02-16"), ("2018/02/15", "16Feb2018"),
+     (pd.datetime(2018, 2, 15), pd.Timestamp(2018, 2, 16))]
+)
 @ifbbg
-def test_bdh_partially_empty_data(con):
+def test_bdh_partially_empty_data(con, start_date, end_date):
     df = con.bdh(
-            tickers=['XIV US Equity', 'AAPL US Equity'],
-            flds=['PX_LAST'],
-            start_date='20180215',
-            end_date='20180216',
-            longdata=False
+        tickers=['XIV US Equity', 'AAPL US Equity'],
+        flds=['PX_LAST'],
+        start_date=start_date,
+        end_date=end_date,
+        longdata=False
     )
     df_exp = pd.DataFrame(
         [[6.04, 172.99], [np.NaN, 172.43]],
         index=pd.DatetimeIndex(["20180215", "20180216"], name="date"),
         columns=pd.MultiIndex.from_product(
-                    [["XIV US Equity", "AAPL US Equity"], ["PX_LAST"]],
-                    names=["ticker", "field"]
-                )
+            [["XIV US Equity", "AAPL US Equity"], ["PX_LAST"]],
+            names=["ticker", "field"]
+        )
     )
     assert_frame_equal(df, df_exp)
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20150629", "2015-06-30"), ("2015/06/29", "30Jun2015"),
+     (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))]
+)
 @ifbbg
-def test_bdh_one_ticker_one_field_pivoted(con):
-    df = con.bdh('SPY US Equity', 'PX_LAST', '20150629', '20150630')
+def test_bdh_one_ticker_one_field_pivoted(con, start_date, end_date):
+    df = con.bdh('SPY US Equity', 'PX_LAST', start_date, end_date)
     midx = pd.MultiIndex(levels=[["SPY US Equity"], ["PX_LAST"]],
                          labels=[[0], [0]], names=["ticker", "field"])
     df_expect = pd.DataFrame(
@@ -159,9 +179,14 @@ def test_bdh_one_ticker_one_field_pivoted(con):
     assert_frame_equal(df, df_expect)
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20150629", "2015-06-30"), ("2015/06/29", "30Jun2015"),
+     (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))]
+)
 @ifbbg
-def test_bdh_one_ticker_one_field_longdata(con):
-    df = con.bdh('SPY US Equity', 'PX_LAST', '20150629', '20150630',
+def test_bdh_one_ticker_one_field_longdata(con, start_date, end_date):
+    df = con.bdh('SPY US Equity', 'PX_LAST', start_date, end_date,
                  longdata=True)
     idx = pd.Index(["date", "ticker", "field", "value"])
     data = [["2015-06-29", "2015-06-30"],
@@ -173,10 +198,15 @@ def test_bdh_one_ticker_one_field_longdata(con):
     assert_frame_equal(df, df_expect)
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20150629", "2015-06-30"), ("2015/06/29", "30Jun2015"),
+     (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))]
+)
 @ifbbg
-def test_bdh_one_ticker_two_field_pivoted(con):
+def test_bdh_one_ticker_two_field_pivoted(con, start_date, end_date):
     cols = ['PX_LAST', 'VOLUME']
-    df = con.bdh('SPY US Equity', cols, '20150629', '20150630')
+    df = con.bdh('SPY US Equity', cols, start_date, end_date)
     midx = pd.MultiIndex(
         levels=[["SPY US Equity"], cols],
         labels=[[0, 0], [0, 1]], names=["ticker", "field"]
@@ -191,10 +221,13 @@ def test_bdh_one_ticker_two_field_pivoted(con):
     assert_frame_equal(df, df_expect)
 
 
+@pytest.mark.parametrize("start_date,end_date", [("20150629", "2015-06-30"),
+                         ("2015/06/29", "30Jun2015"),
+                         (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
 @ifbbg
-def test_bdh_one_ticker_two_field_longdata(con):
+def test_bdh_one_ticker_two_field_longdata(con, start_date, end_date):
     cols = ['PX_LAST', 'VOLUME']
-    df = con.bdh('SPY US Equity', cols, '20150629', '20150630',
+    df = con.bdh('SPY US Equity', cols, start_date, end_date,
                  longdata=True)
     idx = pd.Index(["date", "ticker", "field", "value"])
     data = [["2015-06-29", "2015-06-29", "2015-06-30", "2015-06-30"],
@@ -248,10 +281,13 @@ def test_ref_one_ticker_one_field(con):
     assert_frame_equal(df, df_expect)
 
 
+@pytest.mark.parametrize("date", [("20161010",), ("2016-10-10",),
+                         ("2016/10/10",), ("10Jun2016"),
+                         (pd.datetime(2016, 6, 10),), (pd.Timestamp(2016, 6, 10),)])
 @ifbbg
-def test_ref_one_ticker_one_field_override(con):
+def test_ref_one_ticker_one_field_override(con, date):
     df = con.ref('AUD Curncy', 'SETTLE_DT',
-                 [("REFERENCE_DATE", "20161010")])
+                 [("REFERENCE_DATE", date)])
     df_expect = pd.DataFrame(
         columns=["ticker", "field", "value"],
         data=[["AUD Curncy", "SETTLE_DT",
@@ -309,20 +345,26 @@ def test_ref_mixed_data_error(con):
 
 
 # BULKREF TESTS
+@pytest.mark.parametrize("date", [("20150530",), ("2015-05-30",),
+                         ("2015/05/30",), ("30May2015"),
+                         (pd.datetime(2015, 5, 30),), (pd.Timestamp(2015, 5, 30),)])
 @ifbbg
-def test_bulkref_one_ticker_one_field(con, data_path):
+def test_bulkref_one_ticker_one_field(con, data_path, date):
     df = con.bulkref('BCOM Index', 'INDX_MWEIGHT',
-                     ovrds=[("END_DATE_OVERRIDE", "20150530")])
+                     ovrds=[("END_DATE_OVERRIDE", date)])
     df_expected = pd.read_csv(
         os.path.join(data_path, "bulkref_20150530.csv")
     )
     pivot_and_assert(df, df_expected)
 
 
+@pytest.mark.parametrize("date", [("20150530",), ("2015-05-30",),
+                         ("2015/05/30",), ("30May2015"),
+                         (pd.datetime(2015, 5, 30),), (pd.Timestamp(2015, 5, 30),)])
 @ifbbg
-def test_bulkref_two_ticker_one_field(con, data_path):
+def test_bulkref_two_ticker_one_field(con, data_path, date):
     df = con.bulkref(['BCOM Index', 'OEX Index'], 'INDX_MWEIGHT',
-                     ovrds=[("END_DATE_OVERRIDE", "20150530")])
+                     ovrds=[("END_DATE_OVERRIDE", date)])
     df_expected = pd.read_csv(
         os.path.join(data_path, "bulkref_two_fields_20150530.csv")
     )
@@ -336,11 +378,14 @@ def test_bulkref_singleton_error(con):
         con.bulkref('CL1 Comdty', 'FUT_CUR_GEN_TICKER')
 
 
+@pytest.mark.parametrize("start_date,end_date", [("19860101", "1987-01-01"),
+                         ("1986/01/01", "01Jan87"),
+                         (pd.datetime(1986, 1, 1), pd.Timestamp(1987, 1, 1))])
 @ifbbg
-def test_bulkref_null_scalar_sub_element(con):
+def test_bulkref_null_scalar_sub_element(con, start_date, end_date):
     # related to https://github.com/matthewgilbert/pdblp/issues/32#issuecomment-385555289  # NOQA
     # smoke test to check parse correctly
-    ovrds = [("DVD_START_DT", "19860101"), ("DVD_END_DT", "19870101")]
+    ovrds = [("DVD_START_DT", start_date), ("DVD_END_DT", end_date)]
     con.bulkref("101 HK EQUITY", "DVD_HIST", ovrds=ovrds)
 
 
@@ -375,9 +420,11 @@ def test_bulkref_not_applicable_with_applicable_field_smoketest(con):
 
 
 # REF_HIST TESTS
+@pytest.mark.parametrize("dates", [("20160104", "2016-01-05"),
+                         ("2016/01/04", "05Jan2016"),
+                         (pd.datetime(2016, 1, 4), pd.Timestamp(2016, 1, 5))])
 @ifbbg
-def test_hist_ref_one_ticker_one_field_numeric(con):
-    dates = ["20160104", "20160105"]
+def test_hist_ref_one_ticker_one_field_numeric(con, dates):
     df = con.ref_hist("AUD1M CMPN Curncy", "DAYS_TO_MTY", dates)
     df_expect = pd.DataFrame(
         {"date": dates,
@@ -388,9 +435,11 @@ def test_hist_ref_one_ticker_one_field_numeric(con):
     assert_frame_equal(df, df_expect)
 
 
+@pytest.mark.parametrize("dates", [("20160104", "2016-01-05"),
+                         ("2016/01/04", "05Jan2016"),
+                         (pd.datetime(2016, 1, 4), pd.Timestamp(2016, 1, 5))])
 @ifbbg
-def test_hist_ref_one_ticker_one_field_non_numeric(con):
-    dates = ["20160104", "20160105"]
+def test_hist_ref_one_ticker_one_field_non_numeric(con, dates):
     df = con.ref_hist("AUD1M CMPN Curncy", "SETTLE_DT", dates)
     df_expect = pd.DataFrame(
         {"date": dates,
@@ -402,9 +451,11 @@ def test_hist_ref_one_ticker_one_field_non_numeric(con):
 
 
 # BULKREF_HIST TESTS
+@pytest.mark.parametrize("dates", [("20150530", "2016-05-30"),
+                         ("2015/05/30", "30May16"),
+                         (pd.datetime(2015, 5, 30), pd.Timestamp(2016, 5, 30))])
 @ifbbg
-def test_bulkref_hist_one_field(con, data_path):
-    dates = ["20150530", "20160530"]
+def test_bulkref_hist_one_field(con, data_path, dates):
     df = con.bulkref_hist('BCOM Index', 'INDX_MWEIGHT', dates=dates,
                           date_field='END_DATE_OVERRIDE')
     df_expected = pd.read_csv(
@@ -413,19 +464,24 @@ def test_bulkref_hist_one_field(con, data_path):
     pivot_and_assert(df, df_expected, with_date=True)
 
 
+@pytest.mark.parametrize("dates", [("20160625",), ("2016-06-25",),
+                         ("2016/06/25",), ("25Jun2016",),
+                         (pd.datetime(2016, 6, 25),), (pd.Timestamp(2016, 6, 25),)])
 @ifbbg
-def test_bulkhist_ref_with_alternative_reference_field(con):
+def test_bulkhist_ref_with_alternative_reference_field(con, dates):
     # smoke test to  check that the response was sent off and correctly
     # received
-    dates = ["20160625"]
     con.bulkref_hist("BVIS0587 Index", "CURVE_TENOR_RATES", dates,
                      date_field="CURVE_DATE")
 
 
+@pytest.mark.parametrize("start_date,end_date", [("20150629", "2015-06-30"),
+                         ("2015/06/29", "30Jun2015"),
+                         (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
 @ifbbg
-def test_context_manager(port, host):
+def test_context_manager(port, host, start_date, end_date):
     with pdblp.bopen(host=host, port=port) as bb:
-        df = bb.bdh('SPY US Equity', 'PX_LAST', '20150629', '20150630')
+        df = bb.bdh('SPY US Equity', 'PX_LAST', start_date, end_date)
     midx = pd.MultiIndex(levels=[["SPY US Equity"], ["PX_LAST"]],
                          labels=[[0], [0]], names=["ticker", "field"])
     df_expect = pd.DataFrame(
@@ -478,6 +534,6 @@ def test_bsrch(con):
 
 
 def test_connection_error(port):
-    con = pdblp.BCon(port=port+1)
+    con = pdblp.BCon(port=port + 1)
     with pytest.raises(ConnectionError):
         con.start()

--- a/pdblp/tests/test_pdblp.py
+++ b/pdblp/tests/test_pdblp.py
@@ -221,9 +221,10 @@ def test_bdh_one_ticker_two_field_pivoted(con, start_date, end_date):
     assert_frame_equal(df, df_expect)
 
 
-@pytest.mark.parametrize("start_date,end_date", [("20150629", "2015-06-30"),
-                         ("2015/06/29", "30Jun2015"),
-                         (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20150629", "2015-06-30"), ("2015/06/29", "30Jun2015"),
+     (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
 @ifbbg
 def test_bdh_one_ticker_two_field_longdata(con, start_date, end_date):
     cols = ['PX_LAST', 'VOLUME']
@@ -281,9 +282,10 @@ def test_ref_one_ticker_one_field(con):
     assert_frame_equal(df, df_expect)
 
 
-@pytest.mark.parametrize("date", ["20161010", "2016-10-10",
-                         "2016/10/10", "10Oct2016",
-                         pd.datetime(2016, 10, 10), pd.Timestamp(2016, 10, 10,)])
+@pytest.mark.parametrize(
+    "date",
+    ["20161010", "2016-10-10", "2016/10/10", "10Oct2016",
+     pd.datetime(2016, 10, 10), pd.Timestamp(2016, 10, 10,)])
 @ifbbg
 def test_ref_one_ticker_one_field_override(con, date):
     df = con.ref('AUD Curncy', 'SETTLE_DT',
@@ -345,9 +347,10 @@ def test_ref_mixed_data_error(con):
 
 
 # BULKREF TESTS
-@pytest.mark.parametrize("date", ["20150530", "2015-05-30",
-                         "2015/05/30", "30May2015",
-                         pd.datetime(2015, 5, 30), pd.Timestamp(2015, 5, 30)])
+@pytest.mark.parametrize(
+    "date",
+    ["20150530", "2015-05-30", "2015/05/30", "30May2015",
+     pd.datetime(2015, 5, 30), pd.Timestamp(2015, 5, 30)])
 @ifbbg
 def test_bulkref_one_ticker_one_field(con, data_path, date):
     df = con.bulkref('BCOM Index', 'INDX_MWEIGHT',
@@ -358,9 +361,10 @@ def test_bulkref_one_ticker_one_field(con, data_path, date):
     pivot_and_assert(df, df_expected)
 
 
-@pytest.mark.parametrize("date", ["20150530", "2015-05-30",
-                         "2015/05/30", "30May2015",
-                         pd.datetime(2015, 5, 30), pd.Timestamp(2015, 5, 30)])
+@pytest.mark.parametrize(
+    "date",
+    ["20150530", "2015-05-30", "2015/05/30", "30May2015",
+     pd.datetime(2015, 5, 30), pd.Timestamp(2015, 5, 30)])
 @ifbbg
 def test_bulkref_two_ticker_one_field(con, data_path, date):
     df = con.bulkref(['BCOM Index', 'OEX Index'], 'INDX_MWEIGHT',
@@ -451,9 +455,10 @@ def test_hist_ref_one_ticker_one_field_non_numeric(con, dates):
 
 
 # BULKREF_HIST TESTS
-@pytest.mark.parametrize("dates", [("20150530", "2016-05-30"),
-                         ("2015/05/30", "30May16"),
-                         (pd.datetime(2015, 5, 30), pd.Timestamp(2016, 5, 30))])
+@pytest.mark.parametrize(
+    "dates",
+    [("20150530", "2016-05-30"), ("2015/05/30", "30May16"),
+     (pd.datetime(2015, 5, 30), pd.Timestamp(2016, 5, 30))])
 @ifbbg
 def test_bulkref_hist_one_field(con, data_path, dates):
     df = con.bulkref_hist('BCOM Index', 'INDX_MWEIGHT', dates=dates,
@@ -464,9 +469,9 @@ def test_bulkref_hist_one_field(con, data_path, dates):
     pivot_and_assert(df, df_expected, with_date=True)
 
 
-@pytest.mark.parametrize("dates", [("20160625",), ("2016-06-25",),
-                         ("2016/06/25",), ("25Jun2016",),
-                         (pd.datetime(2016, 6, 25),), (pd.Timestamp(2016, 6, 25),)])
+@pytest.mark.parametrize(
+    "dates", [("20160625",), ("2016-06-25",), ("2016/06/25",), ("25Jun2016",),
+              (pd.datetime(2016, 6, 25),), (pd.Timestamp(2016, 6, 25),)])
 @ifbbg
 def test_bulkhist_ref_with_alternative_reference_field(con, dates):
     # smoke test to  check that the response was sent off and correctly
@@ -475,9 +480,10 @@ def test_bulkhist_ref_with_alternative_reference_field(con, dates):
                      date_field="CURVE_DATE")
 
 
-@pytest.mark.parametrize("start_date,end_date", [("20150629", "2015-06-30"),
-                         ("2015/06/29", "30Jun2015"),
-                         (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [("20150629", "2015-06-30"), ("2015/06/29", "30Jun2015"),
+     (pd.datetime(2015, 6, 29), pd.Timestamp(2015, 6, 30))])
 @ifbbg
 def test_context_manager(port, host, timeout, start_date, end_date):
     with pdblp.bopen(host=host, port=port, timeout=timeout) as bb:


### PR DESCRIPTION
When generating dates dynamically I've found it tedious to convert the objects to the required format.

- [X] Added test cases with various date formats. All the tests pass with two exceptions, `test_bulkref_two_ticker_one_field` and `test_bsrch`. However, these tests currently fail in the main branch as well
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

