### PR TITLE
Changed np.NaN to np.nan for compatibility with NumPy 2.0

### DIFF
--- a/pdblp/pdblp.py
+++ b/pdblp/pdblp.py
@@ -395,7 +395,7 @@ class BCon(object):
                     # that this is a not applicable field, thus set NaN
                     # see https://github.com/matthewgilbert/pdblp/issues/13
                     if fld not in fieldData:
-                        datum = [ticker, fld, np.NaN]
+                        datum = [ticker, fld, np.nan]
                         datum.extend(corrId)
                         data.append(datum)
                     else:
@@ -496,7 +496,7 @@ class BCon(object):
                                 datum.extend(corrId)
                                 data.append(datum)
                     else:  # field is empty or NOT_APPLICABLE_TO_REF_DATA
-                        datum = [ticker, fld, np.NaN, np.NaN, np.NaN]
+                        datum = [ticker, fld, np.nan, np.nan, np.nan]
                         datum.extend(corrId)
                         data.append(datum)
         return data


### PR DESCRIPTION
Hi Matthew,

this PR closes #107 by replacing four instances of `np.NaN` with `np.nan`.

I tried to get the tests to run, but there are some issues due to deprecated features. I fixed the pandas.util.testing import (not included here), but pytest.Config has been changed, so I'm unable to run tests. As the original fix appears to be trivial, I decided to submit it anyways.

Thank you for the great work.